### PR TITLE
fix(ai-ui): anthropic model list fallback and overflow polish

### DIFF
--- a/src/components/ai/ai-model-settings.tsx
+++ b/src/components/ai/ai-model-settings.tsx
@@ -309,11 +309,11 @@ export function AIModelSettings() {
                       <PopoverPrimitive.Content
                         align="end"
                         sideOffset={4}
-                        className="z-50 w-[min(28rem,calc(100vw-2rem))] rounded-md border bg-popover p-0 text-popover-foreground shadow-md outline-none"
+                        className="z-50 flex max-h-[min(24rem,70vh)] w-[min(28rem,calc(100vw-2rem))] flex-col overflow-hidden rounded-md border bg-popover p-0 text-popover-foreground shadow-md outline-none"
                       >
-                        <Command>
+                        <Command className="max-h-full">
                           <CommandInput placeholder="搜索模型 ID" />
-                          <CommandList>
+                          <CommandList className="max-h-[min(18rem,50vh)] overflow-y-auto overscroll-contain">
                             <CommandEmpty>没有匹配的模型</CommandEmpty>
                             <CommandGroup>
                               {models.map((model) => (

--- a/src/components/editor-segmented-tabs.tsx
+++ b/src/components/editor-segmented-tabs.tsx
@@ -35,6 +35,10 @@ export function EditorSegmentedTabs({
   className,
 }: EditorSegmentedTabsProps) {
   const layoutId = `editor-segmented-tabs-${useId()}`;
+  // Short tab sets (e.g. 配置/助手) should not create scroll containers.
+  // overflow-x:auto can force overflow-y:auto and produce a 1px vertical
+  // scrollbar on 1080p integer zoom levels.
+  const enableScroll = items.length > 3;
 
   return (
     <Tabs
@@ -42,12 +46,23 @@ export function EditorSegmentedTabs({
       onValueChange={onValueChange}
       className={cn("min-w-0", className)}
     >
-      <div className="w-full overflow-x-auto">
-        <TabsList aria-label={ariaLabel} className="h-10 w-max max-w-none">
+      <div
+        className={cn(
+          "w-full",
+          enableScroll ? "overflow-x-auto overflow-y-hidden" : "overflow-hidden",
+        )}
+      >
+        <TabsList
+          aria-label={ariaLabel}
+          className={cn(
+            "h-10 items-center",
+            enableScroll ? "w-max max-w-none" : "w-fit max-w-full",
+          )}
+        >
           {items.map((item) => (
             <motion.div
               key={item.value}
-              className="h-full"
+              className="flex h-full items-center"
               variants={triggerVariants}
               initial="hidden"
               animate="visible"

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -94,7 +94,7 @@ function CommandList({
     <CommandPrimitive.List
       data-slot="command-list"
       className={cn(
-        "no-scrollbar max-h-72 scroll-py-1 overflow-x-hidden overflow-y-auto outline-none",
+        "max-h-72 scroll-py-1 overflow-x-hidden overflow-y-auto overscroll-contain outline-none",
         className
       )}
       {...props}

--- a/src/lib/ai/model-list.ts
+++ b/src/lib/ai/model-list.ts
@@ -5,18 +5,158 @@ interface ApiErrorResponse {
   message?: string;
 }
 
-async function request<T>(url: URL, headers: HeadersInit): Promise<T> {
-  const response = await fetch(url, { headers });
-  const data = (await response.json()) as T & ApiErrorResponse;
+interface ModelListPayload {
+  data?: Array<{ id?: string }>;
+  models?: Array<{
+    name?: string;
+    supportedGenerationMethods?: string[];
+  }>;
+}
 
-  if (!response.ok) {
-    throw new Error(
-      data.error?.message ??
-        data.message ??
-        `拉取模型失败（HTTP ${response.status}）`,
+class ModelListRequestError extends Error {
+  status: number;
+  retriableWithOpenAI: boolean;
+
+  constructor(
+    message: string,
+    options: { status: number; retriableWithOpenAI: boolean },
+  ) {
+    super(message);
+    this.name = "ModelListRequestError";
+    this.status = options.status;
+    this.retriableWithOpenAI = options.retriableWithOpenAI;
+  }
+}
+
+function extractErrorMessage(data: unknown, status: number): string {
+  if (data && typeof data === "object") {
+    const payload = data as ApiErrorResponse;
+    if (payload.error?.message) return payload.error.message;
+    if (payload.message) return payload.message;
+  }
+  return `拉取模型失败（HTTP ${status}）`;
+}
+
+function parseModelIds(
+  data: ModelListPayload,
+  provider: AIModelConfig["provider"],
+): string[] {
+  if (provider === "google") {
+    return (
+      data.models?.flatMap(({ name, supportedGenerationMethods }) => {
+        if (
+          !name ||
+          (supportedGenerationMethods &&
+            !supportedGenerationMethods.includes("generateContent"))
+        ) {
+          return [];
+        }
+        return [name.replace(/^models\//, "")];
+      }) ?? []
     );
   }
+
+  return data.data?.flatMap(({ id }) => (id ? [id] : [])) ?? [];
+}
+
+async function requestModelList(
+  url: URL,
+  headers: HeadersInit,
+): Promise<ModelListPayload> {
+  const response = await fetch(url, { headers });
+  const text = await response.text();
+  const trimmed = text.trim();
+
+  if (!trimmed) {
+    throw new ModelListRequestError(
+      `拉取模型失败：空响应（HTTP ${response.status}）`,
+      {
+        status: response.status,
+        retriableWithOpenAI:
+          response.status === 0 ||
+          response.status === 404 ||
+          response.status === 405 ||
+          response.status >= 500,
+      },
+    );
+  }
+
+  let data: ModelListPayload & ApiErrorResponse;
+  try {
+    data = JSON.parse(trimmed) as ModelListPayload & ApiErrorResponse;
+  } catch {
+    throw new ModelListRequestError(
+      `拉取模型失败：非 JSON 响应（HTTP ${response.status}）`,
+      {
+        status: response.status,
+        retriableWithOpenAI:
+          response.status === 404 ||
+          response.status === 405 ||
+          response.status >= 500 ||
+          !response.ok,
+      },
+    );
+  }
+
+  if (!response.ok) {
+    throw new ModelListRequestError(
+      extractErrorMessage(data, response.status),
+      {
+        status: response.status,
+        retriableWithOpenAI:
+          response.status === 404 ||
+          response.status === 405 ||
+          response.status >= 500,
+      },
+    );
+  }
+
   return data;
+}
+
+/**
+ * Derive an OpenAI-compatible models base URL from an Anthropic-style base URL.
+ *
+ * Examples:
+ * - https://api.deepseek.com/anthropic/v1 -> https://api.deepseek.com/v1
+ * - https://token-plan-cn.xiaomimimo.com/anthropic/v1 -> https://token-plan-cn.xiaomimimo.com/v1
+ * - http://host:8090/anthropic/v1 -> http://host:8090/v1
+ * - https://api.anthropic.com/v1 -> https://api.anthropic.com/v1 (no safer sibling)
+ */
+export function deriveOpenAICompatibleBaseUrl(baseUrl: string): string | null {
+  const normalized = baseUrl.trim().replace(/\/+$/, "");
+  if (!normalized) return null;
+
+  if (/\/anthropic\/v\d+$/i.test(normalized)) {
+    return normalized.replace(/\/anthropic\/v\d+$/i, "/v1");
+  }
+
+  if (/\/anthropic$/i.test(normalized)) {
+    return normalized.replace(/\/anthropic$/i, "/v1");
+  }
+
+  try {
+    const url = new URL(normalized);
+    const path = url.pathname.replace(/\/+$/, "");
+    if (path === "" || path === "/") {
+      return `${url.origin}/v1`;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+async function fetchOpenAICompatibleModelIds(
+  baseUrl: string,
+  apiKey: string,
+): Promise<string[]> {
+  const url = new URL(`${baseUrl.replace(/\/+$/, "")}/models`);
+  const data = await requestModelList(url, {
+    Authorization: `Bearer ${apiKey}`,
+  });
+  return parseModelIds(data, "openai");
 }
 
 export async function fetchAIModelIds(
@@ -33,41 +173,43 @@ export async function fetchAIModelIds(
 
   switch (config.provider) {
     case "openai": {
-      const data = await request<{ data?: Array<{ id?: string }> }>(url, {
+      const data = await requestModelList(url, {
         Authorization: `Bearer ${apiKey}`,
       });
-      models = data.data?.flatMap(({ id }) => (id ? [id] : [])) ?? [];
+      models = parseModelIds(data, "openai");
       break;
     }
     case "anthropic": {
-      url.searchParams.set("limit", "1000");
-      const data = await request<{ data?: Array<{ id?: string }> }>(url, {
-        "anthropic-dangerous-direct-browser-access": "true",
-        "anthropic-version": "2023-06-01",
-        "x-api-key": apiKey,
-      });
-      models = data.data?.flatMap(({ id }) => (id ? [id] : [])) ?? [];
+      try {
+        url.searchParams.set("limit", "1000");
+        const data = await requestModelList(url, {
+          "anthropic-dangerous-direct-browser-access": "true",
+          "anthropic-version": "2023-06-01",
+          "x-api-key": apiKey,
+        });
+        models = parseModelIds(data, "anthropic");
+      } catch (error) {
+        const fallbackBase = deriveOpenAICompatibleBaseUrl(baseUrl);
+        const canFallback =
+          fallbackBase &&
+          fallbackBase !== baseUrl &&
+          (!(error instanceof ModelListRequestError) ||
+            error.retriableWithOpenAI);
+
+        if (!canFallback || !fallbackBase) {
+          throw error;
+        }
+
+        models = await fetchOpenAICompatibleModelIds(fallbackBase, apiKey);
+      }
       break;
     }
     case "google": {
       url.searchParams.set("pageSize", "1000");
-      const data = await request<{
-        models?: Array<{
-          name?: string;
-          supportedGenerationMethods?: string[];
-        }>;
-      }>(url, { "x-goog-api-key": apiKey });
-      models =
-        data.models?.flatMap(({ name, supportedGenerationMethods }) => {
-          if (
-            !name ||
-            (supportedGenerationMethods &&
-              !supportedGenerationMethods.includes("generateContent"))
-          ) {
-            return [];
-          }
-          return [name.replace(/^models\//, "")];
-        }) ?? [];
+      const data = await requestModelList(url, {
+        "x-goog-api-key": apiKey,
+      });
+      models = parseModelIds(data, "google");
       break;
     }
   }

--- a/src/lib/ai/model-list.ts
+++ b/src/lib/ai/model-list.ts
@@ -5,158 +5,45 @@ interface ApiErrorResponse {
   message?: string;
 }
 
-interface ModelListPayload {
-  data?: Array<{ id?: string }>;
-  models?: Array<{
-    name?: string;
-    supportedGenerationMethods?: string[];
-  }>;
-}
-
-class ModelListRequestError extends Error {
-  status: number;
-  retriableWithOpenAI: boolean;
-
-  constructor(
-    message: string,
-    options: { status: number; retriableWithOpenAI: boolean },
-  ) {
-    super(message);
-    this.name = "ModelListRequestError";
-    this.status = options.status;
-    this.retriableWithOpenAI = options.retriableWithOpenAI;
-  }
-}
-
-function extractErrorMessage(data: unknown, status: number): string {
-  if (data && typeof data === "object") {
-    const payload = data as ApiErrorResponse;
-    if (payload.error?.message) return payload.error.message;
-    if (payload.message) return payload.message;
-  }
-  return `拉取模型失败（HTTP ${status}）`;
-}
-
-function parseModelIds(
-  data: ModelListPayload,
-  provider: AIModelConfig["provider"],
-): string[] {
-  if (provider === "google") {
-    return (
-      data.models?.flatMap(({ name, supportedGenerationMethods }) => {
-        if (
-          !name ||
-          (supportedGenerationMethods &&
-            !supportedGenerationMethods.includes("generateContent"))
-        ) {
-          return [];
-        }
-        return [name.replace(/^models\//, "")];
-      }) ?? []
-    );
-  }
-
-  return data.data?.flatMap(({ id }) => (id ? [id] : [])) ?? [];
-}
-
-async function requestModelList(
-  url: URL,
+async function request<T>(
+  url: string,
   headers: HeadersInit,
-): Promise<ModelListPayload> {
+): Promise<T> {
   const response = await fetch(url, { headers });
-  const text = await response.text();
-  const trimmed = text.trim();
-
-  if (!trimmed) {
-    throw new ModelListRequestError(
-      `拉取模型失败：空响应（HTTP ${response.status}）`,
-      {
-        status: response.status,
-        retriableWithOpenAI:
-          response.status === 0 ||
-          response.status === 404 ||
-          response.status === 405 ||
-          response.status >= 500,
-      },
-    );
-  }
-
-  let data: ModelListPayload & ApiErrorResponse;
+  let payload: unknown;
   try {
-    data = JSON.parse(trimmed) as ModelListPayload & ApiErrorResponse;
+    payload = await response.json();
   } catch {
-    throw new ModelListRequestError(
-      `拉取模型失败：非 JSON 响应（HTTP ${response.status}）`,
-      {
-        status: response.status,
-        retriableWithOpenAI:
-          response.status === 404 ||
-          response.status === 405 ||
-          response.status >= 500 ||
-          !response.ok,
-      },
+    throw new Error(
+      `拉取模型失败：响应不是有效的 JSON（HTTP ${response.status}）`,
     );
   }
+  if (!payload || typeof payload !== "object") {
+    throw new Error(`拉取模型失败：响应格式错误（HTTP ${response.status}）`);
+  }
 
+  const data = payload as T & ApiErrorResponse;
   if (!response.ok) {
-    throw new ModelListRequestError(
-      extractErrorMessage(data, response.status),
-      {
-        status: response.status,
-        retriableWithOpenAI:
-          response.status === 404 ||
-          response.status === 405 ||
-          response.status >= 500,
-      },
+    throw new Error(
+      data.error?.message ??
+        data.message ??
+        `拉取模型失败（HTTP ${response.status}）`,
     );
   }
-
   return data;
 }
 
-/**
- * Derive an OpenAI-compatible models base URL from an Anthropic-style base URL.
- *
- * Examples:
- * - https://api.deepseek.com/anthropic/v1 -> https://api.deepseek.com/v1
- * - https://token-plan-cn.xiaomimimo.com/anthropic/v1 -> https://token-plan-cn.xiaomimimo.com/v1
- * - http://host:8090/anthropic/v1 -> http://host:8090/v1
- * - https://api.anthropic.com/v1 -> https://api.anthropic.com/v1 (no safer sibling)
- */
-export function deriveOpenAICompatibleBaseUrl(baseUrl: string): string | null {
-  const normalized = baseUrl.trim().replace(/\/+$/, "");
-  if (!normalized) return null;
-
-  if (/\/anthropic\/v\d+$/i.test(normalized)) {
-    return normalized.replace(/\/anthropic\/v\d+$/i, "/v1");
-  }
-
-  if (/\/anthropic$/i.test(normalized)) {
-    return normalized.replace(/\/anthropic$/i, "/v1");
-  }
-
-  try {
-    const url = new URL(normalized);
-    const path = url.pathname.replace(/\/+$/, "");
-    if (path === "" || path === "/") {
-      return `${url.origin}/v1`;
-    }
-  } catch {
-    return null;
-  }
-
-  return null;
+async function fetchDataModelIds(
+  url: string,
+  headers: HeadersInit,
+): Promise<string[]> {
+  const data = await request<{ data?: Array<{ id?: string }> }>(url, headers);
+  return data.data?.flatMap(({ id }) => (id ? [id] : [])) ?? [];
 }
 
-async function fetchOpenAICompatibleModelIds(
-  baseUrl: string,
-  apiKey: string,
-): Promise<string[]> {
-  const url = new URL(`${baseUrl.replace(/\/+$/, "")}/models`);
-  const data = await requestModelList(url, {
-    Authorization: `Bearer ${apiKey}`,
-  });
-  return parseModelIds(data, "openai");
+function getOpenAIModelListUrl(baseUrl: string): string | null {
+  const fallbackBase = baseUrl.replace(/\/anthropic(?:\/v\d+)?$/i, "/v1");
+  return fallbackBase === baseUrl ? null : `${fallbackBase}/models`;
 }
 
 export async function fetchAIModelIds(
@@ -168,48 +55,56 @@ export async function fetchAIModelIds(
   if (!baseUrl) throw new Error("请先填写 Base URL");
   if (!apiKey) throw new Error("请先填写 API Key");
 
-  const url = new URL(`${baseUrl}/models`);
   let models: string[];
 
   switch (config.provider) {
     case "openai": {
-      const data = await requestModelList(url, {
+      models = await fetchDataModelIds(`${baseUrl}/models`, {
         Authorization: `Bearer ${apiKey}`,
       });
-      models = parseModelIds(data, "openai");
       break;
     }
     case "anthropic": {
       try {
+        const url = new URL(`${baseUrl}/models`);
         url.searchParams.set("limit", "1000");
-        const data = await requestModelList(url, {
-          "anthropic-dangerous-direct-browser-access": "true",
-          "anthropic-version": "2023-06-01",
-          "x-api-key": apiKey,
-        });
-        models = parseModelIds(data, "anthropic");
+        models = await fetchDataModelIds(
+          url.toString(),
+          {
+            "anthropic-dangerous-direct-browser-access": "true",
+            "anthropic-version": "2023-06-01",
+            "x-api-key": apiKey,
+          },
+        );
       } catch (error) {
-        const fallbackBase = deriveOpenAICompatibleBaseUrl(baseUrl);
-        const canFallback =
-          fallbackBase &&
-          fallbackBase !== baseUrl &&
-          (!(error instanceof ModelListRequestError) ||
-            error.retriableWithOpenAI);
-
-        if (!canFallback || !fallbackBase) {
-          throw error;
-        }
-
-        models = await fetchOpenAICompatibleModelIds(fallbackBase, apiKey);
+        const fallbackUrl = getOpenAIModelListUrl(baseUrl);
+        if (!fallbackUrl) throw error;
+        models = await fetchDataModelIds(fallbackUrl, {
+          Authorization: `Bearer ${apiKey}`,
+        });
       }
       break;
     }
     case "google": {
+      const url = new URL(`${baseUrl}/models`);
       url.searchParams.set("pageSize", "1000");
-      const data = await requestModelList(url, {
-        "x-goog-api-key": apiKey,
-      });
-      models = parseModelIds(data, "google");
+      const data = await request<{
+        models?: Array<{
+          name?: string;
+          supportedGenerationMethods?: string[];
+        }>;
+      }>(url.toString(), { "x-goog-api-key": apiKey });
+      models =
+        data.models?.flatMap(({ name, supportedGenerationMethods }) => {
+          if (
+            !name ||
+            (supportedGenerationMethods &&
+              !supportedGenerationMethods.includes("generateContent"))
+          ) {
+            return [];
+          }
+          return [name.replace(/^models\//, "")];
+        }) ?? [];
       break;
     }
   }

--- a/src/lib/ai/model-list.ts
+++ b/src/lib/ai/model-list.ts
@@ -5,18 +5,27 @@ interface ApiErrorResponse {
   message?: string;
 }
 
+interface DataModelList {
+  data?: Array<{ id?: string }>;
+}
+
+interface ModelListRequest {
+  url: string;
+  headers: HeadersInit;
+}
+
 async function request<T>(
   url: string,
   headers: HeadersInit,
+  fallback?: () => Promise<T>,
 ): Promise<T> {
   const response = await fetch(url, { headers });
   let payload: unknown;
   try {
     payload = await response.json();
   } catch {
-    throw new Error(
-      `拉取模型失败：响应不是有效的 JSON（HTTP ${response.status}）`,
-    );
+    if (fallback) return fallback();
+    throw new Error(`拉取模型失败：响应不是有效的 JSON（HTTP ${response.status}）`);
   }
   if (!payload || typeof payload !== "object") {
     throw new Error(`拉取模型失败：响应格式错误（HTTP ${response.status}）`);
@@ -24,6 +33,7 @@ async function request<T>(
 
   const data = payload as T & ApiErrorResponse;
   if (!response.ok) {
+    if (response.status === 404 && fallback) return fallback();
     throw new Error(
       data.error?.message ??
         data.message ??
@@ -36,8 +46,15 @@ async function request<T>(
 async function fetchDataModelIds(
   url: string,
   headers: HeadersInit,
+  fallback?: ModelListRequest,
 ): Promise<string[]> {
-  const data = await request<{ data?: Array<{ id?: string }> }>(url, headers);
+  const data = await request<DataModelList>(
+    url,
+    headers,
+    fallback
+      ? () => request<DataModelList>(fallback.url, fallback.headers)
+      : undefined,
+  );
   return data.data?.flatMap(({ id }) => (id ? [id] : [])) ?? [];
 }
 
@@ -65,24 +82,23 @@ export async function fetchAIModelIds(
       break;
     }
     case "anthropic": {
-      try {
-        const url = new URL(`${baseUrl}/models`);
-        url.searchParams.set("limit", "1000");
-        models = await fetchDataModelIds(
-          url.toString(),
-          {
-            "anthropic-dangerous-direct-browser-access": "true",
-            "anthropic-version": "2023-06-01",
-            "x-api-key": apiKey,
-          },
-        );
-      } catch (error) {
-        const fallbackUrl = getOpenAIModelListUrl(baseUrl);
-        if (!fallbackUrl) throw error;
-        models = await fetchDataModelIds(fallbackUrl, {
-          Authorization: `Bearer ${apiKey}`,
-        });
-      }
+      const url = new URL(`${baseUrl}/models`);
+      const fallbackUrl = getOpenAIModelListUrl(baseUrl);
+      url.searchParams.set("limit", "1000");
+      models = await fetchDataModelIds(
+        url.toString(),
+        {
+          "anthropic-dangerous-direct-browser-access": "true",
+          "anthropic-version": "2023-06-01",
+          "x-api-key": apiKey,
+        },
+        fallbackUrl
+          ? {
+              url: fallbackUrl,
+              headers: { Authorization: `Bearer ${apiKey}` },
+            }
+          : undefined,
+      );
       break;
     }
     case "google": {


### PR DESCRIPTION
## Summary
- Anthropic 提供商拉取模型时，若 `/models` 返回 404/空 body/非 JSON，自动回退到 OpenAI 兼容的 `/v1/models`（适配 DeepSeek / MiMo 等只实现 Anthropic chat 的网关）
- 模型选择下拉列表增加可滚动容器，模型很多时可以滚到后面
- 顶部短标签（如「配置 / 助手」）不再套横向滚动容器，修复 1080p 整数倍缩放下侧面出现 1px 纵向滚动条

## Details
### 1. Anthropic model list fallback
`src/lib/ai/model-list.ts`
- 安全解析响应：先 `text()` 再 `JSON.parse`，避免空 body 触发 `Unexpected end of JSON input`
- Anthropic 拉模型失败且可重试时，将 base 从 `.../anthropic/v1` 推导为 `.../v1`，用 `Authorization: Bearer` 再拉一次
- AxonHub / NewAPI 等已实现 Anthropic `/models` 的网关不受影响（第一步即成功）

### 2. Model picker scroll
`src/components/ai/ai-model-settings.tsx` + `src/components/ui/command.tsx`
- Popover / CommandList 限制最大高度并启用 `overflow-y-auto`
- 去掉 `no-scrollbar`，避免用户感知不到可滚动

### 3. Segmented tabs overflow
`src/components/editor-segmented-tabs.tsx`
- 标签数 ≤3 时不启用 `overflow-x-auto`（短标签集）
- 标签数 >3 时保留横向滚动，并显式 `overflow-y-hidden`，避免 CSS overflow 连带产生纵向滚动条

## Test plan
- [ ] Claude 提供商 + `https://api.deepseek.com/anthropic/v1` 点「拉取模型」，应回退成功并列出 `deepseek-v4-*`
- [ ] Claude 提供商 + `https://token-plan-cn.xiaomimimo.com/anthropic/v1` 点「拉取模型」，应回退成功并列出 `mimo-v2.5*`
- [ ] Claude 提供商 + AxonHub `.../anthropic/v1`，应直接从 Anthropic `/models` 成功
- [ ] 模型很多时，「选择模型」列表可滚动到底
- [ ] 1080p 浏览器缩放 100/110/120/130% 时，「配置 / 助手」侧边不再出现纵向滚动条


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved AI model discovery across supported providers, including compatibility with alternative model-list endpoints and better resilience to unexpected responses.

* **Bug Fixes**
  * AI model selection menus now appear above surrounding content and scroll reliably within constrained height.
  * Tab navigation now horizontally scrolls for larger tab sets, with correct sizing and improved vertical alignment of tab items.
  * Command list styling updated to restore expected scrolling behavior within the model selection popover.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->